### PR TITLE
feat: added mock data + slug searching

### DIFF
--- a/cmd/query_svc/query_svc.go
+++ b/cmd/query_svc/query_svc.go
@@ -90,6 +90,7 @@ func (s *querySvcsrvc) payloadToCriteria(ctx context.Context, p *querysvc.QueryR
 		SortBy:       p.Sort,
 		PageToken:    p.PageToken,
 		PageSize:     constants.DefaultPageSize,
+		Slug:         p.Slug,
 	}
 	switch p.Sort {
 	case "name_asc":

--- a/design/query-svc.go
+++ b/design/query-svc.go
@@ -42,6 +42,9 @@ var _ = Service("query-svc", func() {
 			Attribute("tags", ArrayOf(String), "Tags to search (varies by object type)", func() {
 				Example([]string{"active"})
 			})
+			Attribute("slug", String, "Resource slug for filtering", func() {
+				Example("cncf")
+			})
 			Required("bearer_token", "version")
 		})
 
@@ -67,6 +70,7 @@ var _ = Service("query-svc", func() {
 			Param("tags")
 			Param("sort")
 			Param("page_token")
+			Param("slug")
 			Header("bearer_token:Authorization")
 			Response(StatusOK, func() {
 				Header("cache_control:Cache-Control")

--- a/internal/domain/searcher.go
+++ b/internal/domain/searcher.go
@@ -21,6 +21,8 @@ type SearchCriteria struct {
 	Tags []string
 	// Resource name or alias; supports typeahead
 	Name *string
+	// Resource slug for filtering
+	Slug *string
 	// Parent (for navigation; varies by object type)
 	Parent *string
 	// ParentRef is a reference to the parent resource

--- a/internal/infrastructure/mock/searcher.go
+++ b/internal/infrastructure/mock/searcher.go
@@ -30,15 +30,82 @@ func NewMockResourceSearcher() *MockResourceSearcher {
 					"status":      "active",
 					"tags":        []string{"active", "governance"},
 				},
+				TransactionBodyStub: domain.TransactionBodyStub{
+					ObjectRef:           "committee:123",
+					ObjectType:          "committee",
+					ObjectID:            "123",
+					Public:              true,
+					AccessCheckObject:   "committee:123",
+					AccessCheckRelation: "view",
+				},
+			},
+			{
+				Type: "project",
+				ID:   "123",
+				Data: map[string]any{
+					"name":               "Cloud Native Computing Foundation",
+					"slug":               "cncf",
+					"description":        "The Cloud Native Computing Foundation (CNCF) hosts critical components of the global technology infrastructure. CNCF brings together the world’s top developers, end users, and vendors and runs the largest open source developer conferences.",
+					"status":             "active",
+					"logo":               "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/cncf.svg",
+					"tags":               []string{"active", "platform"},
+					"committees_count":   9,
+					"meetings_count":     10,
+					"mailing_list_count": 11,
+				},
+				TransactionBodyStub: domain.TransactionBodyStub{
+					ObjectRef:           "project:123",
+					ObjectType:          "project",
+					ObjectID:            "123",
+					Public:              true,
+					AccessCheckObject:   "project:123",
+					AccessCheckRelation: "view",
+				},
 			},
 			{
 				Type: "project",
 				ID:   "456",
 				Data: map[string]any{
-					"name":        "LFX Platform Project",
-					"description": "Core platform development project",
-					"status":      "active",
-					"tags":        []string{"active", "platform"},
+					"name":               "The Linux Foundation",
+					"slug":               "tlf",
+					"description":        "The Linux Foundation is dedicated to building sustainable ecosystems around open source projects to accelerate technology development and industry adoption. Founded in 2000, the Linux Foundation provides unparalleled support for open source communities through financial and intellectual resources, infrastructure, services, events, and training. Working together, the Linux Foundation and its projects form the most ambitious and successful investment in the creation of shared technology.",
+					"status":             "active",
+					"logo":               "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/thelinuxfoundation-color.svg",
+					"tags":               []string{"active", "platform"},
+					"committees_count":   3,
+					"meetings_count":     3,
+					"mailing_list_count": 3,
+				},
+				TransactionBodyStub: domain.TransactionBodyStub{
+					ObjectRef:           "project:456",
+					ObjectType:          "project",
+					ObjectID:            "456",
+					Public:              true,
+					AccessCheckObject:   "project:456",
+					AccessCheckRelation: "view",
+				},
+			},
+			{
+				Type: "project",
+				ID:   "789",
+				Data: map[string]any{
+					"name":               "Academy Software Foundation",
+					"slug":               "aswf",
+					"description":        "The mission of the Academy Software Foundation (ASWF) is to increase the quality and quantity of contributions to the content creation industry’s open source software base; to provide a neutral forum to coordinate cross-project efforts; to provide a common build and test infrastructure; and to provide individuals and organizations a clear path to participation in advancing our open source ecosystem.",
+					"status":             "active",
+					"logo":               "https://lf-master-project-logos-prod.s3.us-east-2.amazonaws.com/aswf.svg",
+					"tags":               []string{"active", "platform"},
+					"committees_count":   4,
+					"meetings_count":     5,
+					"mailing_list_count": 6,
+				},
+				TransactionBodyStub: domain.TransactionBodyStub{
+					ObjectRef:           "project:789",
+					ObjectType:          "project",
+					ObjectID:            "789",
+					Public:              true,
+					AccessCheckObject:   "project:789",
+					AccessCheckRelation: "view",
 				},
 			},
 			{
@@ -50,6 +117,14 @@ func NewMockResourceSearcher() *MockResourceSearcher {
 					"status":      "active",
 					"tags":        []string{"active", "security"},
 				},
+				TransactionBodyStub: domain.TransactionBodyStub{
+					ObjectRef:           "committee:789",
+					ObjectType:          "committee",
+					ObjectID:            "789",
+					Public:              true,
+					AccessCheckObject:   "committee:789",
+					AccessCheckRelation: "view",
+				},
 			},
 			{
 				Type: "meeting",
@@ -59,6 +134,14 @@ func NewMockResourceSearcher() *MockResourceSearcher {
 					"description": "Regular board meeting for project governance",
 					"status":      "active",
 					"tags":        []string{"active", "governance"},
+				},
+				TransactionBodyStub: domain.TransactionBodyStub{
+					ObjectRef:           "meeting:101",
+					ObjectType:          "meeting",
+					ObjectID:            "101",
+					Public:              true,
+					AccessCheckObject:   "meeting:101",
+					AccessCheckRelation: "view",
 				},
 			},
 		},
@@ -97,6 +180,23 @@ func (m *MockResourceSearcher) QueryResources(ctx context.Context, criteria doma
 			}
 		}
 		filteredResources = nameFilteredResources
+	}
+
+	// Filter by slug (exact match, case-insensitive)
+	if criteria.Slug != nil {
+		var slugFilteredResources []domain.Resource
+		searchSlug := strings.ToLower(*criteria.Slug)
+
+		for _, resource := range filteredResources {
+			if data, ok := resource.Data.(map[string]interface{}); ok {
+				if slug, ok := data["slug"].(string); ok {
+					if strings.ToLower(slug) == searchSlug {
+						slugFilteredResources = append(slugFilteredResources, resource)
+					}
+				}
+			}
+		}
+		filteredResources = slugFilteredResources
 	}
 
 	// Filter by tags


### PR DESCRIPTION
This pull request enhances the `query-svc` service by introducing support for filtering resources using a `slug` attribute. The changes span multiple files, including the addition of the `slug` parameter in API definitions, updates to the domain model, and modifications to the mock searcher to enable slug-based filtering.

### API Enhancements:
* Added a new `slug` parameter to the API request payload and query parameters in `design/query-svc.go`. This allows clients to filter resources by slug. (`[[1]](diffhunk://#diff-ac30e36ebffdfb2c52e4c7bbe00d423d596bef987fa43e03c647057578855ac4R45-R47)`, `[[2]](diffhunk://#diff-ac30e36ebffdfb2c52e4c7bbe00d423d596bef987fa43e03c647057578855ac4R73)`)

### Domain Model Updates:
* Introduced a `Slug` field in the `SearchCriteria` struct in `internal/domain/searcher.go` to represent the slug filter in search criteria. (`[internal/domain/searcher.goR24-R25](diffhunk://#diff-3c1a6ef429e962e30e128d35e87c3195e5185a893389a2bb8339b16f195275d7R24-R25)`)

### Mock Searcher Enhancements:
* Updated the `NewMockResourceSearcher` function in `internal/infrastructure/mock/searcher.go` to include sample resources with slugs, such as "cncf" and "tlf". (`[[1]](diffhunk://#diff-b52d73ff73860af386581f4fcb529a4408f244c8260a24e32cab2c2f4e24dc78R33-R108)`, `[[2]](diffhunk://#diff-b52d73ff73860af386581f4fcb529a4408f244c8260a24e32cab2c2f4e24dc78R120-R127)`, `[[3]](diffhunk://#diff-b52d73ff73860af386581f4fcb529a4408f244c8260a24e32cab2c2f4e24dc78R138-R145)`)
* Implemented slug-based filtering in the `QueryResources` method of `MockResourceSearcher`, ensuring case-insensitive exact matches. (`[internal/infrastructure/mock/searcher.goR185-R201](diffhunk://#diff-b52d73ff73860af386581f4fcb529a4408f244c8260a24e32cab2c2f4e24dc78R185-R201)`)

### Service Logic Updates:
* Modified the `payloadToCriteria` function in `cmd/query_svc/query_svc.go` to map the incoming `slug` parameter to the `SearchCriteria` struct. (`[cmd/query_svc/query_svc.goR93](diffhunk://#diff-459cb6ef9938a573b1baba04e14db0d2995ffe4f059fab9370ce753e1f60248eR93)`)